### PR TITLE
Expose the `mix` method from the Color lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ theme.color.opaquer(0.5)     // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 1.0)
 
 theme.color.rotate(180)      // hsl(60, 20%, 20%) -> hsl(240, 20%, 20%)
 theme.color.rotate(-90)      // hsl(60, 20%, 20%) -> hsl(330, 20%, 20%)
+
+theme.color.mix(theme.otherColor, 0.2) // rgb(0, 0, 255) * 0.8 + rgb(0, 255, 0) * 0.2 -> rgb(0, 51, 204)
 ```
 
 ---

--- a/src/__tests__/addModifier.spec.js
+++ b/src/__tests__/addModifier.spec.js
@@ -14,7 +14,15 @@ const testModifier = (modifier, ...args) => {
 }
 
 describe('addModifier', () => {
-  methods.forEach(method => {
+  it(`adds a mix modifier function`, () => {
+    const otherSelector = () => new Color('#FF0000').toString()
+
+    const modified = addModifer(selector, 'mix', otherSelector, 0.5)
+    expect(modified).toBeA('function')
+    expect(modified()).toEqual(new Color(selector()).mix(new Color(otherSelector()), 0.5))
+  })
+
+  methods.filter(m => m !== 'mix').forEach(method => {
     it(`adds a ${method} modifier function`, () => {
       testModifier(method, 0.1)
       testModifier(method, 0.5)

--- a/src/addModifier.js
+++ b/src/addModifier.js
@@ -5,7 +5,14 @@ import Color from 'color'
  * original function to get the color and then modifies that color, ultimately returning another
  * color string.
  */
-const addModifier = (fn, method, ...modifierArgs) => (...args) =>
-  new Color(fn(...args))[method](...modifierArgs).toString()
+const addModifier = (fn, method, ...modifierArgs) => (...args) => {
+  if (method === 'mix') {
+    // Mix takes another selector. To run the underlying Color method,
+    // convert the selector into a Color by evaluating it with the props.
+    modifierArgs = [].concat(modifierArgs)
+    modifierArgs[0] = new Color(modifierArgs[0](...args));
+  }
+  return new Color(fn(...args))[method](...modifierArgs).toString()
+}
 
 export default addModifier

--- a/src/colorMethods.js
+++ b/src/colorMethods.js
@@ -14,7 +14,9 @@ const colorMethods = [
   'fade', // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 0.4)
   'opaquer', // rgba(10, 10, 10, 0.8) -> rgba(10, 10, 10, 1.0)
 
-  'rotate' // hsl(60, 20%, 20%) -> hsl(330, 20%, 20%)
+  'rotate', // hsl(60, 20%, 20%) -> hsl(330, 20%, 20%)
+
+  'mix', // rgb(0, 0, 255) * 0.8 + rgb(0, 255, 0) * 0.2 -> rgb(0, 51, 204)
 ]
 
 export default colorMethods


### PR DESCRIPTION
I'm using styled-components-theme to build themes for a new app. In the past, I've found the LESS/SCSS `mix` function super helpful because it allows you to blend two colors without needing to know whether the colors are lighter or darker in the theme.

For example, I might say:

- textColor: black
- backgroundColor: white
- subtleTextColor: mix(textColor, backgroundColor, 0.2)

Sometimes you can achieve this with `alpha`, but anyway... I noticed `mix` wasn't implemented and it behaves a bit differently since it needs to be passed a second color. I've added it along with a new test, so you can say something like this:

```
import theme from '../theme';

export const Button = styled.button`
  color: ${theme.colorA.mix(theme.colorB, 0.3)};
`;
```